### PR TITLE
Post Hagenberg changes

### DIFF
--- a/D3310.md
+++ b/D3310.md
@@ -415,19 +415,30 @@ in the opposite direction. A candidate would be better when this conversion is n
 
 # Wording
 
-Add a new paragraph after [temp.pre]{.sref}/9
+Add a new bullet after [over.match.best.general]{.sref}/2.3:
 
-> [9]{.pnum} A template-declaration is written in terms of its template parameters. *[...]*
+> * [2.3]{.pnum} the context is an initialization by conversion function
+> for direct reference binding of a reference to function type, *[...]*
 >
-> :::add
-> [a]{.pnum} A _variant template_ is a template which refers to an original template,
-> introducing a new _template-head_ which is used in place of the original template's _template-head_.
-> This associated _template-head_ is identical to the one in the original template, except that
-> different default arguments might be associated to their corresponding parameters.
-> Variant templates which refer to equivalent templates and which replace the original
-> template's _template-head_ with an equivalent _template-head_ are equivalent to each other,
-> and those which replace it with a _template-head_ which is equivalent to their original template's
-> _template-head_ are equivalent to the original template.
+> ::: add
+> * [2.a]{.pnum} Both F1 and F2 are function template specializations, and there exists a deduced
+> or explicitly specified template template argument A for F2, such that in a determination of whether
+> A matches the corresponding template parameter, the TTP-invented class template&nbsp;([temp.arg.template])
+> for A would use a strict pack match&nbsp;([temp.deduct.type]), and no such template template argument exists for F1.
+>
+> ::: example
+> ```C++
+> template <template <class   > class TT> void f(TT<int>); // #1
+> template <template <class...> class TT> void f(TT<int>); // #2
+>
+> template <class   > struct A {};
+> template <class...> struct B {};
+> void test() {
+>   f(A<int>()); // selects #1 because it is more specialized.
+>   f(B<int>()); // selects #2, see above.
+> }
+> ```
+> :::
 > :::
 
 Combine and modify [temp.arg.template]{.sref} paragraphs 3 and 4, moving the examples to subsequent paragraphs:
@@ -478,9 +489,9 @@ Combine and modify [temp.arg.template]{.sref} paragraphs 3 and 4, moving the exa
 > the function template corresponding to `A`
 > according to the partial ordering rules
 > for function templates&nbsp;([temp.func.order]{.sref}).]{.rm}
-> Given [an invented]{.rm} [a TTP-invented]{.add} class template&nbsp;[([temp.deduct.type])]{.add} `X`
+> Given an invented class template `X`
 > with the *template-head* of `A` (including default arguments
-> and *requires-clause*, if any):
+> and *requires-clause*, if any)[, termed a _TTP-invented class template_]{.add}:
 >
 > * [3.1]{.pnum}
 >   Each of the two function templates has the same template parameters
@@ -565,13 +576,14 @@ Modify and add new paragraphs after [temp.deduct.type]{.sref}/8:
 >
 > :::add
 > [a]{.pnum} If P is a specialization of a template template parameter,
-> the argument corresponding to the parameter
-> is deduced as a variant template ([temp.pre]).
-> Each element of the variant template's _template-head_
-> following the initial sequence of parameters that have a matching argument in P
-> has as its default argument the matching template argument
-> (or a pack of the matching arguments, if the element declares a pack)
-> in `A`.
+> the argument corresponding to the parameter is deduced as a new invented template,
+> which is identical to the original template except for its _template-head_.
+> Each element of the invented template's _template-head_ following the initial sequence
+> of parameters that have a matching argument in P has as its default argument the matching
+> template argument (or a pack of the matching arguments, if the element declares a pack) in `A`.
+> These invented templates, along with their original templates, form an equivalence class,
+> where they are equivalent if and only if they originate from the same template and have equivalent
+> default arguments.
 >
 > ::: example
 > ```C++
@@ -607,9 +619,6 @@ Modify and add new paragraphs after [temp.deduct.type]{.sref}/8:
 > making this a consistent deduction.
 >
 > :::
->
-> [b]{.pnum} A _TTP-invented class template_ is an invented class template used for type deduction
-> when determining whether a template argument matches a template template-parameter ([temp.arg.template]).
 > :::
 >
 > [9]{.pnum} If P has a form that contains \<T\>[,]{.add} [or]{.rm} \<i\>[, or \<TT\>]{.add},
@@ -629,7 +638,7 @@ Modify and add new paragraphs after [temp.deduct.type]{.sref}/8:
 >   parameter packs expanded by P~i~.
 >
 > * [9.2]{.pnum}
->   [If P is a TTP-invented class template, P uses a _strict pack match_ when a non-pack argument
+>   [If P is a TTP-invented class template&nbsp;([temp.arg.template]), P uses a _strict pack match_ when a non-pack argument
 >   in its argument list matches a pack expansion in A.]{.add}
 >
 > * [9.3]{.pnum}
@@ -642,7 +651,7 @@ Modify and add new paragraphs after [temp.deduct.type]{.sref}/8:
 >   * [9.3.3]{.pnum} otherwise, if P~i~ is not a pack expansion, template argument deduction fails.
 >
 > * [9.4]{.pnum} [When deducing the argument list of the specializations of a
-> TTP-invented class template ([temp.deduct.type]), if A~i~ is a pack expansion,
+> TTP-invented class template&nbsp;([temp.arg.template]), if A~i~ is a pack expansion,
 > and there is at least one remaining argument in P, then the pattern of A~i~ is
 > compared with each remaining argument in the template argument list of P.
 > Each comparison deduces template arguments for subsequent positions in the
@@ -653,37 +662,25 @@ Modify and add new paragraphs after [temp.deduct.type]{.sref}/8:
 > The last two bullets are the reverse of each other.
 > :::
 
-Add a new bullet after [over.match.best.general]{.sref}/2.3:
+Add a new bullet to [temp.spec.partial.match]{.sref}/1 and append a new example to the next paragraph:
 
-> * [2.3]{.pnum} the context is an initialization by conversion function
-> for direct reference binding of a reference to function type, *[...]*
+> [1]{.pnum} When a template is used in a context that requires an instantiation of the template,
+> it is necessary to determine whether the instantiation is to be generated using the primary template
+> or one of the partial specializations. This is done by matching the template arguments of the template
+> specialization with the template argument lists of the partial specializations.
+>
+> * Each of the two function templates has the same template parameters and associated constraints as the corresponding partial specialization.
+>
+> * Each function template has a single function parameter whose type is a class template specialization where the template arguments are the corresponding template parameters from the function template for each template argument in the template-argument-list of the simple-template-id of the partial specialization.
 >
 > ::: add
-> * [2.a]{.pnum} Both F1 and F2 are function template specializations, and there exists a deduced
-> or explicitly specified template template argument A for F2, such that in a determination of whether
-> A matches the corresponding template parameter ([temp.arg.template]), the TTP-invented class template
-> for A would use a strict pack match, and no such template template argument exists for F1.
->
-> ::: example
-> ```C++
-> template <template <class   > class TT> void f(TT<int>); // #1
-> template <template <class...> class TT> void f(TT<int>); // #2
->
-> template <class   > struct A {};
-> template <class...> struct B {};
-> void test() {
->   f(A<int>()); // selects #1 because it is more specialized.
->   f(B<int>()); // selects #2, see above.
-> }
-> ```
+> * If a matching specialization (including the primary template) uses a strict pack match&nbsp;([temp.deduct.type]),
+> that specialization is considered only if there are no matching specializations that do not use a strict pack match.
 > :::
-> :::
-
-Add a new example to [temp.spec.partial.order]{.sref}/1:
-
-> [1]{.pnum} For two partial specializations, the first is more specialized than the second if,
-> given the following rewrite to two function templates, the first function template is more
-> specialized than the second according to the ordering rules for function templates:
+>
+> [2]{.pnum}[*[...]*]{.example}
+>
+> [*[...]*]{.example}
 >
 > ::: add
 > ::: example


### PR DESCRIPTION
* Remove variant template, inline definition into use.
* Add rules for class template partial ordering, which mirror the overload resolution penalty to strict-pack-matches.
* Move up changes to [over], before [tmp] changes, in order to match the standard order.
* Remove hyphen from 'template template-parameter'.
* Move the definition of 'TTP-invented class template' to [temp.arg.template]